### PR TITLE
feat: make shutdown hook registration configurable

### DIFF
--- a/src/main/java/berlin/yuna/natsserver/config/NatsStreamingConfig.java
+++ b/src/main/java/berlin/yuna/natsserver/config/NatsStreamingConfig.java
@@ -119,6 +119,7 @@ public enum NatsStreamingConfig {
 
     //WRAPPER configs
     NATS_AUTOSTART(null, true, Boolean.class, "[true] == auto closable, [false] == manual use `.start()` method (default: true)"),
+    NATS_SHUTDOWN_HOOK(null, true, Boolean.class, "[true] == registers a shutdown hook, [false] == manual use `.stop()` method (default: true)"),
     NATS_LOG_LEVEL(null, null, String.class, "java log level e.g. [OFF, SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL]"),
     NATS_TIMEOUT_MS(null, 10000, String.class, "true = auto closable, false manual use `.start()` method"),
     NATS_SYSTEM(null, null, String.class, "suffix for binary path"),

--- a/src/main/java/berlin/yuna/natsserver/config/NatsStreamingOptionsBuilder.java
+++ b/src/main/java/berlin/yuna/natsserver/config/NatsStreamingOptionsBuilder.java
@@ -216,7 +216,6 @@ public class NatsStreamingOptionsBuilder {
         return getValueB(configMap, NatsStreamingConfig.NATS_AUTOSTART);
     }
 
-
     /**
      * @param autostart true = auto closable, false manual use `.start()` method
      * @return self {@link NatsStreamingOptionsBuilder}
@@ -224,6 +223,24 @@ public class NatsStreamingOptionsBuilder {
      */
     public NatsStreamingOptionsBuilder autostart(final Boolean autostart) {
         setValueB(configMap, NatsStreamingConfig.NATS_AUTOSTART, autostart);
+        return this;
+    }
+
+    /**
+     * @return true = registers a shutdown hook, false manual use `.stop()` method
+     * @see NatsStreamingConfig#NATS_SHUTDOWN_HOOK
+     */
+    public Boolean shutdownHook() {
+        return getValueB(configMap, NatsStreamingConfig.NATS_SHUTDOWN_HOOK);
+    }
+
+    /**
+     * @param enabled true = registers a shutdown hook, false manual use `.stop()` method
+     * @return self {@link NatsStreamingOptionsBuilder}
+     * @see NatsStreamingConfig#NATS_SHUTDOWN_HOOK
+     */
+    public NatsStreamingOptionsBuilder shutdownHook(final Boolean enabled) {
+        setValueB(configMap, NatsStreamingConfig.NATS_SHUTDOWN_HOOK, enabled);
         return this;
     }
 

--- a/src/main/java/berlin/yuna/natsserver/logic/NatsStreaming.java
+++ b/src/main/java/berlin/yuna/natsserver/logic/NatsStreaming.java
@@ -123,7 +123,8 @@ public class NatsStreaming implements NatsInterface {
      * @param natsOptions nats options
      */
     public NatsStreaming(final io.nats.commons.NatsOptions natsOptions) {
-        Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+        ofNullable(getValue(NATS_SHUTDOWN_HOOK)).filter(Boolean::valueOf)
+                .ifPresent(shutdownHook -> Runtime.getRuntime().addShutdownHook(new Thread(this::close)));
         final var timeoutMsTmp = new AtomicLong(-1);
         if (natsOptions instanceof NatsStreamingOptions) {
             ((NatsStreamingOptions) natsOptions).config().forEach(this::addConfig);

--- a/src/test/java/berlin/yuna/natsserver/config/NatsStreamingOptionsBuilderTest.java
+++ b/src/test/java/berlin/yuna/natsserver/config/NatsStreamingOptionsBuilderTest.java
@@ -77,6 +77,14 @@ class NatsStreamingOptionsBuilderTest {
         options.autostart(true);
         assertThat(options.autostart(), is(equalTo(true)));
 
+        //SHUTDOWN HOOK
+        assertThat(options.shutdownHook(), is(nullValue()));
+        options.shutdownHook(false);
+        assertThat(options.shutdownHook(), is(equalTo(false)));
+
+        options.shutdownHook(true);
+        assertThat(options.shutdownHook(), is(equalTo(true)));
+
         //CONFIG_FILE
         assertThat(options.configFile(), is(nullValue()));
         options.configFile(configFile);
@@ -112,9 +120,9 @@ class NatsStreamingOptionsBuilderTest {
         assertThat(options.timeoutMs(), is(equalTo(timeoutMs)));
 
         //OPTIONS BUILD
-        assertThat(options.configMap().size(), is(10));
+        assertThat(options.configMap().size(), is(11));
         final var build = options.build();
-        assertThat(build.config().size(), is(10));
+        assertThat(build.config().size(), is(11));
 
         assertThat(build.version(), is(equalTo(version.value())));
         assertThat(build.port(), is(equalTo(port)));
@@ -129,7 +137,7 @@ class NatsStreamingOptionsBuilderTest {
         assertThat(build.config().get(NatsStreamingConfig.NATS_TIMEOUT_MS), is(equalTo(String.valueOf(timeoutMs))));
 
         //OPTIONS INTERFACE
-        assertThat(options.configMap().size(), is(10));
+        assertThat(options.configMap().size(), is(11));
         final var interFace = (io.nats.commons.NatsOptions) options.build();
 
         assertThat(interFace.port(), is(equalTo(port)));


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
  - [x] New feature (non-breaking change which adds functionality)

## Motivation
This change gives the users control back to choose if they need an automatic shutdown hook or want to do graceful shutdown in a controlled order themselves.

In my particular use case, I start a NATS server as a `@Bean` in Spring Boot Test and was expecting the container to handle calling `#close()` in a defined oder (first, connections relying on the server, then server) but found that the server closes prematurely making the graceful shutdown impossible.

## Changes
* Adds a new `NATS_SHUTDOWN_HOOK` config option
* As well as `.shutdownHook(Boolean)` setter/getter
* That switches on/off shutdown hook registration 
* Defaulting to `true` so that this change is fully backwards compatible 

